### PR TITLE
Provided option to perform page snap without animation

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -985,10 +985,14 @@ public class PDFView extends RelativeLayout {
         }
     }
 
+    public void performPageSnap() {
+        performPageSnap(true);
+    }
+
     /**
      * Animate to the nearest snapping position for the current SnapPolicy
      */
-    public void performPageSnap() {
+    public void performPageSnap(boolean withAnimation) {
         if (!pageSnap || pdfFile == null || pdfFile.getPagesCount() == 0) {
             return;
         }
@@ -1000,9 +1004,17 @@ public class PDFView extends RelativeLayout {
 
         float offset = snapOffsetForPage(centerPage, edge);
         if (swipeVertical) {
-            animationManager.startYAnimation(currentYOffset, -offset);
+            if (withAnimation) {
+                animationManager.startYAnimation(currentYOffset, -offset);
+            } else {
+                moveTo(currentXOffset, -offset);
+            }
         } else {
-            animationManager.startXAnimation(currentXOffset, -offset);
+            if (withAnimation) {
+                animationManager.startXAnimation(currentXOffset, -offset);
+            } else {
+                moveTo(-offset, currentYOffset);
+            }
         }
     }
 


### PR DESCRIPTION
I had a use case where I have to disable page swipe and jump to pages programmatically where I should show one page at a time. To center the page in the view, I call `performPageSnap` from `onPageChange` listener, but this page snap is done with an animation which is not needed for me. So I gave an option to perform page snap without animation in this PR.