### PR TITLE
Replace PdfiumAndroid with PdfiumAndroidKt

### DIFF
--- a/android-pdf-viewer/build.gradle
+++ b/android-pdf-viewer/build.gradle
@@ -1,17 +1,17 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "3.2.0-beta.1"
     }
 }
 
 dependencies {
-    implementation 'androidx.core:core:1.3.1'
-    api 'com.github.TalbotGooday:PdfiumAndroid:1.0.1'
+    implementation 'androidx.core:core:1.12.0'
+    api 'io.legere:pdfiumandroid:1.0.19'
 }

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DecodingAsyncTask.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DecodingAsyncTask.java
@@ -18,9 +18,9 @@ package com.github.barteksc.pdfviewer;
 import android.os.AsyncTask;
 
 import com.github.barteksc.pdfviewer.source.DocumentSource;
-import com.shockwave.pdfium.PdfDocument;
-import com.shockwave.pdfium.PdfiumCore;
-import com.shockwave.pdfium.util.Size;
+import io.legere.pdfiumandroid.PdfDocument;
+import io.legere.pdfiumandroid.PdfiumCore;
+import io.legere.pdfiumandroid.util.Size;
 
 import java.lang.ref.WeakReference;
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
@@ -17,6 +17,7 @@ package com.github.barteksc.pdfviewer;
 
 import android.graphics.PointF;
 import android.graphics.RectF;
+import android.util.SizeF;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
@@ -25,8 +26,7 @@ import android.view.View;
 import com.github.barteksc.pdfviewer.model.LinkTapEvent;
 import com.github.barteksc.pdfviewer.scroll.ScrollHandle;
 import com.github.barteksc.pdfviewer.util.SnapEdge;
-import com.shockwave.pdfium.PdfDocument;
-import com.shockwave.pdfium.util.SizeF;
+import io.legere.pdfiumandroid.PdfDocument;
 
 import static com.github.barteksc.pdfviewer.util.Constants.Pinch.MAXIMUM_ZOOM;
 import static com.github.barteksc.pdfviewer.util.Constants.Pinch.MINIMUM_ZOOM;

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -34,6 +34,7 @@ import android.os.Build;
 import android.os.HandlerThread;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.util.SizeF;
 import android.widget.RelativeLayout;
 
 import com.github.barteksc.pdfviewer.exception.PageRenderingException;
@@ -62,10 +63,10 @@ import com.github.barteksc.pdfviewer.util.FitPolicy;
 import com.github.barteksc.pdfviewer.util.MathUtils;
 import com.github.barteksc.pdfviewer.util.SnapEdge;
 import com.github.barteksc.pdfviewer.util.Util;
-import com.shockwave.pdfium.PdfDocument;
-import com.shockwave.pdfium.PdfiumCore;
-import com.shockwave.pdfium.util.Size;
-import com.shockwave.pdfium.util.SizeF;
+import io.legere.pdfiumandroid.PdfDocument;
+import io.legere.pdfiumandroid.PdfiumCore;
+import io.legere.pdfiumandroid.util.Config;
+import io.legere.pdfiumandroid.util.Size;
 
 import java.io.File;
 import java.io.InputStream;
@@ -310,7 +311,7 @@ public class PDFView extends RelativeLayout {
         debugPaint = new Paint();
         debugPaint.setStyle(Style.STROKE);
 
-        pdfiumCore = new PdfiumCore(context);
+        pdfiumCore = new PdfiumCore(context, new Config());
         setWillNotDraw(false);
     }
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PagesLoader.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PagesLoader.java
@@ -17,10 +17,10 @@ package com.github.barteksc.pdfviewer;
 
 import android.graphics.RectF;
 
+import android.util.SizeF;
 import com.github.barteksc.pdfviewer.util.Constants;
 import com.github.barteksc.pdfviewer.util.MathUtils;
 import com.github.barteksc.pdfviewer.util.Util;
-import com.shockwave.pdfium.util.SizeF;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
@@ -18,15 +18,15 @@ package com.github.barteksc.pdfviewer;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.util.SizeF;
 import android.util.SparseBooleanArray;
 
 import com.github.barteksc.pdfviewer.exception.PageRenderingException;
 import com.github.barteksc.pdfviewer.util.FitPolicy;
 import com.github.barteksc.pdfviewer.util.PageSizeCalculator;
-import com.shockwave.pdfium.PdfDocument;
-import com.shockwave.pdfium.PdfiumCore;
-import com.shockwave.pdfium.util.Size;
-import com.shockwave.pdfium.util.SizeF;
+import io.legere.pdfiumandroid.PdfDocument;
+import io.legere.pdfiumandroid.PdfiumCore;
+import io.legere.pdfiumandroid.util.Size;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -98,7 +98,7 @@ class PdfFile {
         if (originalUserPages != null) {
             pagesCount = originalUserPages.length;
         } else {
-            pagesCount = pdfiumCore.getPageCount(pdfDocument);
+            pagesCount = pdfDocument.getPageCount();
         }
 
         for (int i = 0; i < pagesCount; i++) {
@@ -324,7 +324,7 @@ class PdfFile {
     public RectF mapRectToDevice(int pageIndex, int startX, int startY, int sizeX, int sizeY,
                                  RectF rect) {
         int docPage = documentPage(pageIndex);
-        return pdfiumCore.mapRectToDevice(pdfDocument, docPage, startX, startY, sizeX, sizeY, 0, rect);
+        return new RectF(pdfDocument.openPage(docPage).mapRectToDevice(startX, startY, sizeX, sizeY, 0, rect));
     }
 
     public void dispose() {

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/model/LinkTapEvent.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/model/LinkTapEvent.java
@@ -16,8 +16,7 @@
 package com.github.barteksc.pdfviewer.model;
 
 import android.graphics.RectF;
-
-import com.shockwave.pdfium.PdfDocument;
+import io.legere.pdfiumandroid.PdfDocument;
 
 public class LinkTapEvent {
     private float originalX;

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/AssetSource.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/AssetSource.java
@@ -20,8 +20,8 @@ import android.content.Context;
 import android.os.ParcelFileDescriptor;
 
 import com.github.barteksc.pdfviewer.util.FileUtils;
-import com.shockwave.pdfium.PdfDocument;
-import com.shockwave.pdfium.PdfiumCore;
+import io.legere.pdfiumandroid.PdfDocument;
+import io.legere.pdfiumandroid.PdfiumCore;
 
 import java.io.File;
 import java.io.IOException;

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/ByteArraySource.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/ByteArraySource.java
@@ -16,9 +16,8 @@
 package com.github.barteksc.pdfviewer.source;
 
 import android.content.Context;
-
-import com.shockwave.pdfium.PdfDocument;
-import com.shockwave.pdfium.PdfiumCore;
+import io.legere.pdfiumandroid.PdfDocument;
+import io.legere.pdfiumandroid.PdfiumCore;
 
 import java.io.IOException;
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/DocumentSource.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/DocumentSource.java
@@ -16,9 +16,8 @@
 package com.github.barteksc.pdfviewer.source;
 
 import android.content.Context;
-
-import com.shockwave.pdfium.PdfDocument;
-import com.shockwave.pdfium.PdfiumCore;
+import io.legere.pdfiumandroid.PdfDocument;
+import io.legere.pdfiumandroid.PdfiumCore;
 
 import java.io.IOException;
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/FileSource.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/FileSource.java
@@ -17,9 +17,8 @@ package com.github.barteksc.pdfviewer.source;
 
 import android.content.Context;
 import android.os.ParcelFileDescriptor;
-
-import com.shockwave.pdfium.PdfDocument;
-import com.shockwave.pdfium.PdfiumCore;
+import io.legere.pdfiumandroid.PdfDocument;
+import io.legere.pdfiumandroid.PdfiumCore;
 
 import java.io.File;
 import java.io.IOException;

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/InputStreamSource.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/InputStreamSource.java
@@ -18,8 +18,8 @@ package com.github.barteksc.pdfviewer.source;
 import android.content.Context;
 
 import com.github.barteksc.pdfviewer.util.Util;
-import com.shockwave.pdfium.PdfDocument;
-import com.shockwave.pdfium.PdfiumCore;
+import io.legere.pdfiumandroid.PdfDocument;
+import io.legere.pdfiumandroid.PdfiumCore;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/UriSource.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/source/UriSource.java
@@ -18,9 +18,8 @@ package com.github.barteksc.pdfviewer.source;
 import android.content.Context;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
-
-import com.shockwave.pdfium.PdfDocument;
-import com.shockwave.pdfium.PdfiumCore;
+import io.legere.pdfiumandroid.PdfDocument;
+import io.legere.pdfiumandroid.PdfiumCore;
 
 import java.io.IOException;
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/util/PageSizeCalculator.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/util/PageSizeCalculator.java
@@ -15,11 +15,8 @@
  */
 package com.github.barteksc.pdfviewer.util;
 
-import android.app.Activity;
-import android.util.Log;
-import android.content.pm.ActivityInfo;
-import com.shockwave.pdfium.util.Size;
-import com.shockwave.pdfium.util.SizeF;
+import android.util.SizeF;
+import io.legere.pdfiumandroid.util.Size;
 
 public class PageSizeCalculator {
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,18 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
+android.suppressUnsupportedCompileSdk=34
 android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-android.suppressUnsupportedCompileSdk=34
 android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 04 20:30:19 EEST 2020
+#Mon Mar 04 14:32:05 EST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.pdfviewer"
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 3
         versionName "3.0.0"
     }
@@ -22,5 +22,5 @@ android {
 
 dependencies {
     implementation project(':android-pdf-viewer')
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
 		android:theme="@style/Theme.AppCompat.Light">
 		<activity
 			android:name=".PDFViewActivity"
-			android:label="@string/app_name" >
+			android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />

--- a/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
+++ b/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
@@ -41,7 +41,7 @@ import com.github.barteksc.pdfviewer.listener.OnPageChangeListener;
 import com.github.barteksc.pdfviewer.listener.OnPageErrorListener;
 import com.github.barteksc.pdfviewer.scroll.DefaultScrollHandle;
 import com.github.barteksc.pdfviewer.util.FitPolicy;
-import com.shockwave.pdfium.PdfDocument;
+import io.legere.pdfiumandroid.PdfDocument;
 
 import java.util.List;
 
@@ -199,14 +199,13 @@ public class PDFViewActivity extends AppCompatActivity implements OnPageChangeLi
     public String getFileName(Uri uri) {
         String result = null;
         if (uri.getScheme().equals("content")) {
-            Cursor cursor = getContentResolver().query(uri, null, null, null, null);
-            try {
+            try (Cursor cursor = getContentResolver().query(uri, null, null, null, null)) {
                 if (cursor != null && cursor.moveToFirst()) {
-                    result = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
-                }
-            } finally {
-                if (cursor != null) {
-                    cursor.close();
+                    int columnIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+
+                    if (columnIndex >= 0) {
+                        result = cursor.getString(columnIndex);
+                    }
                 }
             }
         }
@@ -237,7 +236,7 @@ public class PDFViewActivity extends AppCompatActivity implements OnPageChangeLi
 
             Log.e(TAG, String.format("%s %s, p %d", sep, b.getTitle(), b.getPageIdx()));
 
-            if (b.hasChildren()) {
+            if (!b.getChildren().isEmpty()) {
                 printBookmarksTree(b.getChildren(), sep + "-");
             }
         }
@@ -251,8 +250,9 @@ public class PDFViewActivity extends AppCompatActivity implements OnPageChangeLi
      * @param grantResults Whether permissions granted
      */
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[],
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         if (requestCode == PERMISSION_CODE) {
             if (grantResults.length > 0
                     && grantResults[0] == PackageManager.PERMISSION_GRANTED) {


### PR DESCRIPTION
__This is a breaking change to the library.__

PdfiumAndroid relies on pretty old versions of PDFium. PdfiumAndroidKt is a rewrite of that library in Kotlin with updated native libraries. It also depends on API 21.

This PR:
- Updates the minimum SDK to 21 to match PdfiumAndroidKt.
- Updates the compile and target SDKs to 34 and makes necessary compat changes.
- Updates the AndroidX dependencies.
- Replaces JCenter repository declarations with Maven Central.
- Updates AGP to 7.4.2.
- Replaces the PdfiumAndroid dependency with PdfiumAndroidKt.
- Updates imports as necessary to reference PdfiumAndroidKt instead of PdfiumAndroid.
- Adds a JitPack config file so the library can successfully build.

Consumers of the library (e.g., `react-native-pdf`) will need to update any transitive imports of PdfiumAndroid to PdfiumAndroidKt when updating to a version containing the changes in this PR.